### PR TITLE
fix(Viewport): specify viewport in head

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ destroy();
 
 - It is recommended to leave no gaps in the `breakpoints` object. It can also be advantageous to set up `breakpoints` in a such a way that there is always a matching query. (Ex: Using breakpoints for 'too small' or 'too big' to cover all of the sizes that aren't meaningful in your application.) This pattern should be more useful than the previously available `default` key in the `breakpoints` object which was only active when there was no matching query.
 
+- In some cases, media queries - and by extension Respondable - will not be applied as expected on mobile devices if the viewport is not set explicitly. This is explained well [here](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag). To avoid this, consider including `<meta name="viewport" content="width=device-width >` in the `head` of your `document`.
+
 ## Demo
 
 Clone this repo and open `example/demo.html` in your browser to test it out.

--- a/example/demo.html
+++ b/example/demo.html
@@ -1,4 +1,7 @@
 <html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+  </head>
   <body>
     <script src='../dist/index.min.js'></script>
     <style>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   ],
   "contributors": [
     "Brandon Dail <cottoncrypt@gmail.com>",
-    "Nathan Schwartz <nathan.schwartz95@gmail.com>"
+    "Nathan Schwartz <nathan.schwartz95@gmail.com>",
+    "Ari Frankel <ari.l.frankel@gmail.com>"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This adds a viewport meta tag to the head of the demo html file to set
content width to device-width. Doing so fixes an issue with the example that's been
observed in chrome inspector and mobile devices where the wrong screen size is active. This is explained [here](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag) 

This also adds a note to the docs explaining that this is needed.